### PR TITLE
Add Exa Agent notebook for football manager research

### DIFF
--- a/EXA_Agent_Extended_Football_Managers.ipynb
+++ b/EXA_Agent_Extended_Football_Managers.ipynb
@@ -1,0 +1,656 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "source": [
+        "! pip install -q exa_py"
+      ],
+      "metadata": {
+        "id": "uYfiJuIrv2l0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "73a94ff1-5db7-40bc-c5cb-cfb7ca23c9c3"
+      },
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\u001b[?25l   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m0.0/85.7 kB\u001b[0m \u001b[31m?\u001b[0m eta \u001b[36m-:--:--\u001b[0m\r\u001b[2K   \u001b[91m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[90m╺\u001b[0m\u001b[90m━\u001b[0m \u001b[32m81.9/85.7 kB\u001b[0m \u001b[31m141.5 MB/s\u001b[0m eta \u001b[36m0:00:01\u001b[0m\r\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m85.7/85.7 kB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25h"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# ── CONFIG ── Edit this cell to change companies or the research task ──────────────\n",
+        "\n",
+        "MANAGERS = [\n",
+        "    {\"manager\": \"Jose Mourinho\"},\n",
+        "    {\"manager\": \"Pep Guardiola\"},\n",
+        "]\n",
+        "\n",
+        "RESEARCH_QUERY = \"\"\"\n",
+        "For each input manager, produce a tactical and career research brief covering:\n",
+        "- Tactical philosophy and preferred system (formation, pressing style, build-up approach, defensive shape)\n",
+        "- Career history and key clubs managed, with notable results and trophy haul\n",
+        "- Signature strengths and what makes them distinctive as a manager\n",
+        "- Known weaknesses or recurring criticisms (e.g. player relationships, late-career patterns)\n",
+        "- How their style compares to peers and rivals — key contrasts and competitive rivalries\n",
+        "- Source URLs backing the research\n",
+        "\"\"\"\n"
+      ],
+      "metadata": {
+        "id": "config_cell"
+      },
+      "execution_count": 4,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from exa_py import Exa\n",
+        "from google.colab import userdata\n",
+        "import json\n",
+        "Exa_key = userdata.get('EXA_KEY')\n",
+        "exa = Exa(api_key=Exa_key)\n"
+      ],
+      "metadata": {
+        "id": "2CWt2tHDv8fm"
+      },
+      "execution_count": 3,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "run = exa.beta.agent.runs.create(\n",
+        "    betas=[\"agent-2026-05-07\"],\n",
+        "    query=RESEARCH_QUERY,\n",
+        "    input={\"data\": MANAGERS},\n",
+        "    output_schema={\n",
+        "        \"type\": \"object\",\n",
+        "        \"required\": [\"reports\"],\n",
+        "        \"properties\": {\n",
+        "            \"reports\": {\n",
+        "                \"type\": \"array\",\n",
+        "                \"items\": {\n",
+        "                    \"type\": \"object\",\n",
+        "                    \"required\": [\n",
+        "                        \"manager\",\n",
+        "                        \"overview\",\n",
+        "                        \"tacticalSystem\",\n",
+        "                        \"careerHistory\",\n",
+        "                        \"keyStrengths\",\n",
+        "                        \"weaknesses\",\n",
+        "                        \"peerComparisons\",\n",
+        "                        \"sourceUrls\",\n",
+        "                    ],\n",
+        "                    \"properties\": {\n",
+        "                        \"manager\": {\"type\": \"string\"},\n",
+        "                        \"overview\": {\"type\": \"string\"},\n",
+        "                        \"tacticalSystem\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                        \"careerHistory\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                        \"keyStrengths\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                        \"weaknesses\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                        \"peerComparisons\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                        \"sourceUrls\": {\n",
+        "                            \"type\": \"array\",\n",
+        "                            \"items\": {\"type\": \"string\", \"format\": \"uri\"},\n",
+        "                            \"minItems\": 1,\n",
+        "                        },\n",
+        "                    },\n",
+        "                },\n",
+        "            }\n",
+        "        },\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(json.dumps(run.model_dump(), indent=2))"
+      ],
+      "metadata": {
+        "id": "c1U-QYrEv5WC",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "284955a5-edf3-438f-845a-9d4ccd263184",
+        "collapsed": true
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "{\n",
+            "  \"id\": \"agent_run_eaf3e54634db44a5b8edc3b62bf10484\",\n",
+            "  \"object\": \"agent_run\",\n",
+            "  \"status\": \"running\",\n",
+            "  \"stop_reason\": null,\n",
+            "  \"created_at\": \"2026-06-22T14:10:27.511Z\",\n",
+            "  \"completed_at\": null,\n",
+            "  \"request\": {\n",
+            "    \"query\": \"\\nFor each input manager, produce a tactical and career research brief covering:\\n- Tactical philosophy and preferred system (formation, pressing style, build-up approach, defensive shape)\\n- Career history and key clubs managed, with notable results and trophy haul\\n- Signature strengths and what makes them distinctive as a manager\\n- Known weaknesses or recurring criticisms (e.g. player relationships, late-career patterns)\\n- How their style compares to peers and rivals \\u2014 key contrasts and competitive rivalries\\n- Source URLs backing the research\\n\",\n",
+            "    \"input\": {\n",
+            "      \"data\": [\n",
+            "        {\n",
+            "          \"manager\": \"Jose Mourinho\"\n",
+            "        },\n",
+            "        {\n",
+            "          \"manager\": \"Pep Guardiola\"\n",
+            "        }\n",
+            "      ]\n",
+            "    },\n",
+            "    \"outputSchema\": {\n",
+            "      \"type\": \"object\",\n",
+            "      \"required\": [\n",
+            "        \"reports\"\n",
+            "      ],\n",
+            "      \"properties\": {\n",
+            "        \"reports\": {\n",
+            "          \"type\": \"array\",\n",
+            "          \"items\": {\n",
+            "            \"type\": \"object\",\n",
+            "            \"required\": [\n",
+            "              \"manager\",\n",
+            "              \"overview\",\n",
+            "              \"tacticalSystem\",\n",
+            "              \"careerHistory\",\n",
+            "              \"keyStrengths\",\n",
+            "              \"weaknesses\",\n",
+            "              \"peerComparisons\",\n",
+            "              \"sourceUrls\"\n",
+            "            ],\n",
+            "            \"properties\": {\n",
+            "              \"manager\": {\n",
+            "                \"type\": \"string\"\n",
+            "              },\n",
+            "              \"overview\": {\n",
+            "                \"type\": \"string\"\n",
+            "              },\n",
+            "              \"tacticalSystem\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              },\n",
+            "              \"careerHistory\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              },\n",
+            "              \"keyStrengths\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              },\n",
+            "              \"weaknesses\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              },\n",
+            "              \"peerComparisons\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              },\n",
+            "              \"sourceUrls\": {\n",
+            "                \"type\": \"array\",\n",
+            "                \"items\": {\n",
+            "                  \"type\": \"string\",\n",
+            "                  \"format\": \"uri\"\n",
+            "                },\n",
+            "                \"minItems\": 1\n",
+            "              }\n",
+            "            }\n",
+            "          }\n",
+            "        }\n",
+            "      }\n",
+            "    },\n",
+            "    \"effort\": \"auto\"\n",
+            "  },\n",
+            "  \"output\": {\n",
+            "    \"text\": \"\",\n",
+            "    \"structured\": null,\n",
+            "    \"grounding\": []\n",
+            "  },\n",
+            "  \"usage\": {\n",
+            "    \"agent_compute_units\": 0.0,\n",
+            "    \"searches\": 0,\n",
+            "    \"emails\": 0,\n",
+            "    \"phone_numbers\": 0\n",
+            "  },\n",
+            "  \"cost_dollars\": {\n",
+            "    \"total\": 0.0,\n",
+            "    \"agent_compute\": 0.0,\n",
+            "    \"search\": 0.0,\n",
+            "    \"emails\": 0.0,\n",
+            "    \"phone_numbers\": 0.0\n",
+            "  },\n",
+            "  \"error\": null\n",
+            "}\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "completed_run = exa.beta.agent.runs.poll_until_finished(\n",
+        "    run.id, betas=[\"agent-2026-05-07\"]\n",
+        ")\n",
+        "print(completed_run.output.structured if completed_run.output else None)\n"
+      ],
+      "metadata": {
+        "id": "6I02bYzsw9CT",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5f04a8c8-a731-44d3-dde6-859a4616416f"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "{'reports': [{'manager': 'Jose Mourinho', 'overview': 'José Mourinho is an elite results-first manager whose identity is built on tactical pragmatism, defensive control, psychological edge and knockout-game management. His peak run — Porto, first Chelsea spell, Inter and Real Madrid — made him one of modern football’s defining coaches: a Champions League winner with Porto and Inter, a league champion in Portugal, England, Italy and Spain, and a manager whose methods became the counterpoint to possession orthodoxy.', 'sourceUrls': ['https://en.wikipedia.org/wiki/Jos%C3%A9_Mourinho', 'https://www.transfermarkt.com/transfermarkt/profil/trainer/781', 'https://www.transfermarkt.com/jose-mourinho/erfolge/trainer/781', 'https://www.angeloquarenghi.com/en/jose-mourinho-tactical-evolution/', 'https://playerdevelopmentproject.com/jose-mourinho-the-price-of-success/', 'https://www.goal.com/en-gb/lists/genius-jose-mourinho-spoil-tactics-explained-former-benfica-star-ex-chelsea-boss-change-style-player-power/blt3aba73f90da82846', 'https://www.adidas-group.com/en/magazine/behind-the-scenes/jose-mourinho-a-winning-and-leadership-style-that-transcends-sport'], 'weaknesses': ['Style criticism: often criticised for reactive, low-possession football, ‘parking the bus’ and prioritising winning over entertainment or attacking development.', 'Player relationships: recurring tension with star players and dressing rooms, including late-spell breakdowns at Chelsea, Real Madrid and Manchester United; modern player power is often cited as making his confrontational methods harder to sustain.', 'Late-career pattern: strong initial impact can give way to friction, public conflict and declining results by the second or third season.', 'Tactical modernity concerns: critics argue that his lower-block, opponent-spoiling approach has sometimes lagged behind high-pressing, positional and possession trends.', 'Attacking ceiling: teams can become dependent on moments, set pieces, transitions or target-men rather than sustained chance creation against deep opponents.'], 'keyStrengths': ['Elite opponent-specific preparation: Mourinho’s best teams were designed to deny rivals their preferred zones and rhythms rather than simply impose one aesthetic.', 'Big-game and knockout management: two Champions League titles with non-superclub favourites Porto and Inter, plus multiple European trophies, underscore his ability to build tournament-winning plans.', 'Defensive organisation and transition mastery: his sides are known for compactness, rest-defence, quick counters and exploiting transition moments.', 'Psychological leadership: built powerful ‘us against the world’ cultures and often used media pressure to protect or galvanise squads.', 'Midfield control through structure: from Porto’s diamond to Chelsea’s 4-3-3, Mourinho repeatedly sought numerical or positional midfield superiority.', 'Adaptability across leagues: won league titles in Portugal, England, Italy and Spain and European trophies with several clubs.'], 'careerHistory': ['Early pathway: youth and assistant roles in Portugal, then translator/assistant roles under Bobby Robson and Louis van Gaal at Sporting, Porto and Barcelona, before senior jobs at Benfica and União de Leiria.', 'Porto, 2002–2004: won the Portuguese league twice, Portuguese Cup, UEFA Cup in 2002–03 and Champions League in 2003–04 — the breakout that made him a global manager.', 'Chelsea, 2004–2007: transformed English football with a 4-3-3/Makelele-role structure; won Premier League titles in 2004–05 and 2005–06, plus domestic cups, with a famously dominant and defensively secure side.', 'Inter Milan, 2008–2010: won Serie A twice and delivered the 2009–10 treble — Serie A, Coppa Italia and Champions League — one of his career-defining achievements.', 'Real Madrid, 2010–2013: won Copa del Rey, La Liga in 2011–12 and Spanish Super Cup, building a devastating counterattacking side to challenge Guardiola’s Barcelona.', 'Chelsea second spell, 2013–2015: won another Premier League title in 2014–15 and League Cup, before a sharp downturn and dismissal.', 'Manchester United, 2016–2018: won the League Cup, Community Shield and Europa League in 2016–17; also finished second in the Premier League in 2017–18.', 'Tottenham, 2019–2021: reached a League Cup final but was dismissed before it; trophyless spell reinforced late-career questions.', 'Roma, 2021–2024: won the inaugural UEFA Europa Conference League in 2021–22 and reached the 2022–23 Europa League final.', 'Fenerbahçe and Benfica in mid-2020s per Transfermarkt listings: continued his late-career pattern of taking major but complex, high-pressure jobs.'], 'tacticalSystem': ['Preferred base: commonly listed as 4-2-3-1 in later career, but historically flexible: Porto used a diamond 4-4-2; first Chelsea popularised a 4-3-3 with Claude Makélélé as the free screening midfielder; Inter alternated 4-2-3-1/4-3-1-2; Roma later leaned into 3-4-1-2/3-5-2 and deeper blocks.', 'Pressing/defensive style: early Porto could press high with a high line and intense fitness; later Mourinho sides became more reactive, compact and low-to-mid block oriented, prioritising central denial, defensive awareness and transition protection.', 'Build-up/attack: less concerned with sterile possession than with territory, verticality and transition. His best sides attacked quickly through midfield and wide channels, often using powerful reference forwards and direct runners.', 'Defensive shape: typically compact, midfield-superiority focused and opponent-specific; he is famous for ceding possession when strategically useful, closing central corridors and forcing elite possession teams wide, exemplified by Inter against Guardiola’s Barcelona in 2010.', 'Game model: strongly associated with tactical periodisation — training physical, technical and tactical work around the intended game model rather than isolating them.'], 'peerComparisons': ['Versus Pep Guardiola: Mourinho is the emblem of reactive control and opponent denial; Guardiola represents proactive possession, positional play and territorial dominance. Their Barcelona–Inter and Barcelona–Real Madrid rivalry became an ideological clash.', 'Versus Arsène Wenger: Mourinho’s Chelsea was the pragmatic, physically robust antithesis to Wenger’s idealistic, technical Arsenal, and their Premier League rivalry was both tactical and personal.', 'Versus Jürgen Klopp: Mourinho’s approach is more controlled and risk-managed; Klopp’s peak sides relied more on aggressive counter-pressing, tempo and emotional intensity.', 'Versus Diego Simeone: both value compactness, defensive sacrifice and transitions, but Simeone’s Atlético identity is more stable and club-culture based, while Mourinho is more itinerant and opponent-specific.', 'Historical comparison: frequently likened to Helenio Herrera for charisma, controversy, defensive acumen and results-first pragmatism.']}, {'manager': 'Pep Guardiola', 'overview': 'Pep Guardiola is the most influential possession-and-positional-play coach of the modern era, a Cruyff-influenced manager who has won at historic rates while reshaping how elite teams build from the back, press after loss and use hybrid player roles. His managerial résumé spans Barcelona, Bayern Munich and Manchester City, with 40-plus total trophies reported in 2026 sources and a tactical legacy that extends far beyond silverware.', 'sourceUrls': ['https://en.wikipedia.org/wiki/Pep_Guardiola', 'https://www.bbc.co.uk/sport/football/articles/cn8p34e12nno', 'https://www.bbc.com/sport/football/articles/cn8p34e12nno', 'https://www.thehindu.com/sport/football/pep-guardiola-the-manager-who-stood-tall/article71042521.ece', 'https://www.straitstimes.com/sport/football/pep-guardiola-catalan-genius-who-changed-football', 'https://sports.yahoo.com/articles/architect-redefined-football-why-guardiola-055756222.html', 'https://www.espn.com/soccer/story/_/id/48845495/pep-guardiola-manager-season-ranking-barcelona-manchester-city-bayern-munich', 'https://www.aa.com.tr/en/sports/profile-pep-guardiola-exits-after-conquering-football-and-speaking-beyond-it/3947537'], 'weaknesses': ['Overthinking criticism: often accused of excessive tactical tinkering in major Champions League knockout games, especially the 2021 final when City omitted a natural holding midfielder and lost to Chelsea.', 'Transition vulnerability: because his teams commit numbers high and build short, turnovers can expose space if counter-pressing or rest-defence fails.', 'Resource criticism: detractors note that his success came at Barcelona, Bayern and Abu Dhabi-backed Manchester City — clubs with elite squads and major financial power.', 'European shortfall at Bayern/early City: despite domestic dominance, he did not win the Champions League at Bayern and waited until 2023 to win it with City.', 'Intensity and control demands: his micro-management and cognitive load can be exhausting for players over long cycles, contributing to the need for squad refreshes.', 'Off-field/political scrutiny: public positions and guarded responses on issues linked to Manchester City ownership or wider politics have drawn both praise and criticism.'], 'keyStrengths': ['System-building: creates repeatable attacking and defensive mechanisms that make teams dominate territory, possession and chance quality.', 'Tactical innovation: normalised false nines, inverted full-backs, hybrid centre-back/midfielders and goalkeeper-led build-up at elite and grassroots levels.', 'Adaptability within principles: while rooted in possession, he continually altered structures across Spain, Germany and England and adapted to different player profiles, from Messi to Haaland.', 'Player development and role reinvention: repeatedly improved elite players by moving them into unfamiliar roles and refining decision-making within positional structures.', 'Sustained winning: won major honours in three countries and repeatedly refreshed title-winning teams across cycles.', 'Influence on coaching culture: his ideas changed recruitment, academy coaching, build-up expectations and the tactical vocabulary of modern football.'], 'careerHistory': ['Barcelona B, 2007–2008: won promotion from Spain’s fourth tier/third division level, earning the first-team job.', 'Barcelona, 2008–2012: won 14 trophies in four years, including the 2008–09 treble of La Liga, Copa del Rey and Champions League, and another Champions League in 2010–11; built one of football’s most celebrated club sides around Messi, Xavi and Iniesta.', 'Bayern Munich, 2013–2016: won seven trophies in three seasons, including three Bundesliga titles, while deepening his positional-play ideas in Germany, though without a Champions League win.', 'Manchester City, 2016–2026 per 2026 sources: won six Premier League titles, three FA Cups, five League Cups, the 2022–23 Champions League, UEFA Super Cup and FIFA Club World Cup; completed the 2022–23 treble and an unprecedented four straight English league titles from 2021 to 2024.', 'Overall haul: 2026 reports cite around 41 career trophies and roughly 20 or 21 at Manchester City, placing him among the most decorated managers in football history.'], 'tacticalSystem': ['Preferred structures: nominal formations shift — 4-3-3, 3-2-4-1, 4-2-3-1 variants — but the constant is positional play: spacing, occupation of lanes, overloads and control through the ball.', 'Pressing style: collective high press and rapid counter-press, often described through a six-second regain principle; teams try to win the ball quickly in advanced areas where opponents have less space and organisation.', 'Build-up approach: goalkeeper and centre-backs are part of construction; Guardiola sides insist on playing out from the back under pressure, using rotations, third-man combinations and midfield overloads.', 'Defensive shape: possession itself is a defensive tool, but out of possession his sides defend by compressing space high, controlling rest-defence and committing tactical fouls or counter-presses to stop transitions.', 'Signature innovations: Messi as false nine at Barcelona; inverted full-backs at Bayern and City; centre-backs stepping into midfield; John Stones used in a hybrid midfield/no.8 role; City winning without a recognised centre-forward before later adapting around Erling Haaland.', 'Philosophical roots: Johan Cruyff and Barcelona positional play, with influences also linked to Juanma Lillo, Marcelo Bielsa, La Volpe, Luis Aragonés and Arrigo Sacchi-style pressing/collective movement.'], 'peerComparisons': ['Versus José Mourinho: Guardiola is proactive, possession-based and system-led; Mourinho is reactive, opponent-specific and transition/defence-led. Their rivalry defined the Barcelona–Real Madrid and Barcelona–Inter eras as a tactical culture war.', 'Versus Jürgen Klopp: Guardiola’s City sought control through possession and positional structure; Klopp’s Liverpool used ‘heavy-metal’ tempo, verticality and gegenpressing. Their Premier League rivalry pushed both to historic standards.', 'Versus Johan Cruyff: Guardiola is Cruyff’s most successful managerial heir, extending Barcelona positional ideas across Europe, though he publicly rejects being equated with Cruyff’s unique charisma and club-changing role.', 'Versus Marcelo Bielsa: both influenced by aggressive pressing and attacking ideology, but Guardiola is more control-oriented and risk-managed, while Bielsa is more man-to-man, vertical and physically extreme.', 'Versus Arrigo Sacchi: Guardiola has been described through an ‘offensive Sacchi’ lens — collective movement, compactness and pressing, but with possession as the central organising principle.']}]}\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import display, Markdown\n",
+        "\n",
+        "if completed_run.output and completed_run.output.structured:\n",
+        "    reports = completed_run.output.structured.get('reports', [])\n",
+        "    for report in reports:\n",
+        "        display(Markdown(f\"## {report['manager']}\"))\n",
+        "        display(Markdown(f\"**Overview:** {report['overview']}\"))\n",
+        "\n",
+        "        display(Markdown(\"**Tactical System:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- {t}\" for t in report['tacticalSystem'])))\n",
+        "\n",
+        "        display(Markdown(\"**Career History:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- {h}\" for h in report['careerHistory'])))\n",
+        "\n",
+        "        display(Markdown(\"**Key Strengths:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- {s}\" for s in report['keyStrengths'])))\n",
+        "\n",
+        "        display(Markdown(\"**Weaknesses:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- {w}\" for w in report['weaknesses'])))\n",
+        "\n",
+        "        display(Markdown(\"**Peer Comparisons:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- {p}\" for p in report['peerComparisons'])))\n",
+        "\n",
+        "        display(Markdown(\"**Sources:**\"))\n",
+        "        display(Markdown(\"\\n\".join(f\"- [{url}]({url})\" for url in report['sourceUrls'])))\n",
+        "\n",
+        "        display(Markdown(\"---\"))\n",
+        "else:\n",
+        "    print(\"No structured output found to display.\")"
+      ],
+      "metadata": {
+        "id": "1f11269e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "collapsed": true,
+        "outputId": "c9a0ecb3-1c8e-40bc-aa0a-01616b13defc"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "## Jose Mourinho"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Overview:** José Mourinho is an elite results-first manager whose identity is built on tactical pragmatism, defensive control, psychological edge and knockout-game management. His peak run — Porto, first Chelsea spell, Inter and Real Madrid — made him one of modern football’s defining coaches: a Champions League winner with Porto and Inter, a league champion in Portugal, England, Italy and Spain, and a manager whose methods became the counterpoint to possession orthodoxy."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Tactical System:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Preferred base: commonly listed as 4-2-3-1 in later career, but historically flexible: Porto used a diamond 4-4-2; first Chelsea popularised a 4-3-3 with Claude Makélélé as the free screening midfielder; Inter alternated 4-2-3-1/4-3-1-2; Roma later leaned into 3-4-1-2/3-5-2 and deeper blocks.\n- Pressing/defensive style: early Porto could press high with a high line and intense fitness; later Mourinho sides became more reactive, compact and low-to-mid block oriented, prioritising central denial, defensive awareness and transition protection.\n- Build-up/attack: less concerned with sterile possession than with territory, verticality and transition. His best sides attacked quickly through midfield and wide channels, often using powerful reference forwards and direct runners.\n- Defensive shape: typically compact, midfield-superiority focused and opponent-specific; he is famous for ceding possession when strategically useful, closing central corridors and forcing elite possession teams wide, exemplified by Inter against Guardiola’s Barcelona in 2010.\n- Game model: strongly associated with tactical periodisation — training physical, technical and tactical work around the intended game model rather than isolating them."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Career History:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Early pathway: youth and assistant roles in Portugal, then translator/assistant roles under Bobby Robson and Louis van Gaal at Sporting, Porto and Barcelona, before senior jobs at Benfica and União de Leiria.\n- Porto, 2002–2004: won the Portuguese league twice, Portuguese Cup, UEFA Cup in 2002–03 and Champions League in 2003–04 — the breakout that made him a global manager.\n- Chelsea, 2004–2007: transformed English football with a 4-3-3/Makelele-role structure; won Premier League titles in 2004–05 and 2005–06, plus domestic cups, with a famously dominant and defensively secure side.\n- Inter Milan, 2008–2010: won Serie A twice and delivered the 2009–10 treble — Serie A, Coppa Italia and Champions League — one of his career-defining achievements.\n- Real Madrid, 2010–2013: won Copa del Rey, La Liga in 2011–12 and Spanish Super Cup, building a devastating counterattacking side to challenge Guardiola’s Barcelona.\n- Chelsea second spell, 2013–2015: won another Premier League title in 2014–15 and League Cup, before a sharp downturn and dismissal.\n- Manchester United, 2016–2018: won the League Cup, Community Shield and Europa League in 2016–17; also finished second in the Premier League in 2017–18.\n- Tottenham, 2019–2021: reached a League Cup final but was dismissed before it; trophyless spell reinforced late-career questions.\n- Roma, 2021–2024: won the inaugural UEFA Europa Conference League in 2021–22 and reached the 2022–23 Europa League final.\n- Fenerbahçe and Benfica in mid-2020s per Transfermarkt listings: continued his late-career pattern of taking major but complex, high-pressure jobs."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Key Strengths:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Elite opponent-specific preparation: Mourinho’s best teams were designed to deny rivals their preferred zones and rhythms rather than simply impose one aesthetic.\n- Big-game and knockout management: two Champions League titles with non-superclub favourites Porto and Inter, plus multiple European trophies, underscore his ability to build tournament-winning plans.\n- Defensive organisation and transition mastery: his sides are known for compactness, rest-defence, quick counters and exploiting transition moments.\n- Psychological leadership: built powerful ‘us against the world’ cultures and often used media pressure to protect or galvanise squads.\n- Midfield control through structure: from Porto’s diamond to Chelsea’s 4-3-3, Mourinho repeatedly sought numerical or positional midfield superiority.\n- Adaptability across leagues: won league titles in Portugal, England, Italy and Spain and European trophies with several clubs."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Weaknesses:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Style criticism: often criticised for reactive, low-possession football, ‘parking the bus’ and prioritising winning over entertainment or attacking development.\n- Player relationships: recurring tension with star players and dressing rooms, including late-spell breakdowns at Chelsea, Real Madrid and Manchester United; modern player power is often cited as making his confrontational methods harder to sustain.\n- Late-career pattern: strong initial impact can give way to friction, public conflict and declining results by the second or third season.\n- Tactical modernity concerns: critics argue that his lower-block, opponent-spoiling approach has sometimes lagged behind high-pressing, positional and possession trends.\n- Attacking ceiling: teams can become dependent on moments, set pieces, transitions or target-men rather than sustained chance creation against deep opponents."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Peer Comparisons:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Versus Pep Guardiola: Mourinho is the emblem of reactive control and opponent denial; Guardiola represents proactive possession, positional play and territorial dominance. Their Barcelona–Inter and Barcelona–Real Madrid rivalry became an ideological clash.\n- Versus Arsène Wenger: Mourinho’s Chelsea was the pragmatic, physically robust antithesis to Wenger’s idealistic, technical Arsenal, and their Premier League rivalry was both tactical and personal.\n- Versus Jürgen Klopp: Mourinho’s approach is more controlled and risk-managed; Klopp’s peak sides relied more on aggressive counter-pressing, tempo and emotional intensity.\n- Versus Diego Simeone: both value compactness, defensive sacrifice and transitions, but Simeone’s Atlético identity is more stable and club-culture based, while Mourinho is more itinerant and opponent-specific.\n- Historical comparison: frequently likened to Helenio Herrera for charisma, controversy, defensive acumen and results-first pragmatism."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Sources:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- [https://en.wikipedia.org/wiki/Jos%C3%A9_Mourinho](https://en.wikipedia.org/wiki/Jos%C3%A9_Mourinho)\n- [https://www.transfermarkt.com/transfermarkt/profil/trainer/781](https://www.transfermarkt.com/transfermarkt/profil/trainer/781)\n- [https://www.transfermarkt.com/jose-mourinho/erfolge/trainer/781](https://www.transfermarkt.com/jose-mourinho/erfolge/trainer/781)\n- [https://www.angeloquarenghi.com/en/jose-mourinho-tactical-evolution/](https://www.angeloquarenghi.com/en/jose-mourinho-tactical-evolution/)\n- [https://playerdevelopmentproject.com/jose-mourinho-the-price-of-success/](https://playerdevelopmentproject.com/jose-mourinho-the-price-of-success/)\n- [https://www.goal.com/en-gb/lists/genius-jose-mourinho-spoil-tactics-explained-former-benfica-star-ex-chelsea-boss-change-style-player-power/blt3aba73f90da82846](https://www.goal.com/en-gb/lists/genius-jose-mourinho-spoil-tactics-explained-former-benfica-star-ex-chelsea-boss-change-style-player-power/blt3aba73f90da82846)\n- [https://www.adidas-group.com/en/magazine/behind-the-scenes/jose-mourinho-a-winning-and-leadership-style-that-transcends-sport](https://www.adidas-group.com/en/magazine/behind-the-scenes/jose-mourinho-a-winning-and-leadership-style-that-transcends-sport)"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "---"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "## Pep Guardiola"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Overview:** Pep Guardiola is the most influential possession-and-positional-play coach of the modern era, a Cruyff-influenced manager who has won at historic rates while reshaping how elite teams build from the back, press after loss and use hybrid player roles. His managerial résumé spans Barcelona, Bayern Munich and Manchester City, with 40-plus total trophies reported in 2026 sources and a tactical legacy that extends far beyond silverware."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Tactical System:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Preferred structures: nominal formations shift — 4-3-3, 3-2-4-1, 4-2-3-1 variants — but the constant is positional play: spacing, occupation of lanes, overloads and control through the ball.\n- Pressing style: collective high press and rapid counter-press, often described through a six-second regain principle; teams try to win the ball quickly in advanced areas where opponents have less space and organisation.\n- Build-up approach: goalkeeper and centre-backs are part of construction; Guardiola sides insist on playing out from the back under pressure, using rotations, third-man combinations and midfield overloads.\n- Defensive shape: possession itself is a defensive tool, but out of possession his sides defend by compressing space high, controlling rest-defence and committing tactical fouls or counter-presses to stop transitions.\n- Signature innovations: Messi as false nine at Barcelona; inverted full-backs at Bayern and City; centre-backs stepping into midfield; John Stones used in a hybrid midfield/no.8 role; City winning without a recognised centre-forward before later adapting around Erling Haaland.\n- Philosophical roots: Johan Cruyff and Barcelona positional play, with influences also linked to Juanma Lillo, Marcelo Bielsa, La Volpe, Luis Aragonés and Arrigo Sacchi-style pressing/collective movement."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Career History:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Barcelona B, 2007–2008: won promotion from Spain’s fourth tier/third division level, earning the first-team job.\n- Barcelona, 2008–2012: won 14 trophies in four years, including the 2008–09 treble of La Liga, Copa del Rey and Champions League, and another Champions League in 2010–11; built one of football’s most celebrated club sides around Messi, Xavi and Iniesta.\n- Bayern Munich, 2013–2016: won seven trophies in three seasons, including three Bundesliga titles, while deepening his positional-play ideas in Germany, though without a Champions League win.\n- Manchester City, 2016–2026 per 2026 sources: won six Premier League titles, three FA Cups, five League Cups, the 2022–23 Champions League, UEFA Super Cup and FIFA Club World Cup; completed the 2022–23 treble and an unprecedented four straight English league titles from 2021 to 2024.\n- Overall haul: 2026 reports cite around 41 career trophies and roughly 20 or 21 at Manchester City, placing him among the most decorated managers in football history."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Key Strengths:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- System-building: creates repeatable attacking and defensive mechanisms that make teams dominate territory, possession and chance quality.\n- Tactical innovation: normalised false nines, inverted full-backs, hybrid centre-back/midfielders and goalkeeper-led build-up at elite and grassroots levels.\n- Adaptability within principles: while rooted in possession, he continually altered structures across Spain, Germany and England and adapted to different player profiles, from Messi to Haaland.\n- Player development and role reinvention: repeatedly improved elite players by moving them into unfamiliar roles and refining decision-making within positional structures.\n- Sustained winning: won major honours in three countries and repeatedly refreshed title-winning teams across cycles.\n- Influence on coaching culture: his ideas changed recruitment, academy coaching, build-up expectations and the tactical vocabulary of modern football."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Weaknesses:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Overthinking criticism: often accused of excessive tactical tinkering in major Champions League knockout games, especially the 2021 final when City omitted a natural holding midfielder and lost to Chelsea.\n- Transition vulnerability: because his teams commit numbers high and build short, turnovers can expose space if counter-pressing or rest-defence fails.\n- Resource criticism: detractors note that his success came at Barcelona, Bayern and Abu Dhabi-backed Manchester City — clubs with elite squads and major financial power.\n- European shortfall at Bayern/early City: despite domestic dominance, he did not win the Champions League at Bayern and waited until 2023 to win it with City.\n- Intensity and control demands: his micro-management and cognitive load can be exhausting for players over long cycles, contributing to the need for squad refreshes.\n- Off-field/political scrutiny: public positions and guarded responses on issues linked to Manchester City ownership or wider politics have drawn both praise and criticism."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Peer Comparisons:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- Versus José Mourinho: Guardiola is proactive, possession-based and system-led; Mourinho is reactive, opponent-specific and transition/defence-led. Their rivalry defined the Barcelona–Real Madrid and Barcelona–Inter eras as a tactical culture war.\n- Versus Jürgen Klopp: Guardiola’s City sought control through possession and positional structure; Klopp’s Liverpool used ‘heavy-metal’ tempo, verticality and gegenpressing. Their Premier League rivalry pushed both to historic standards.\n- Versus Johan Cruyff: Guardiola is Cruyff’s most successful managerial heir, extending Barcelona positional ideas across Europe, though he publicly rejects being equated with Cruyff’s unique charisma and club-changing role.\n- Versus Marcelo Bielsa: both influenced by aggressive pressing and attacking ideology, but Guardiola is more control-oriented and risk-managed, while Bielsa is more man-to-man, vertical and physically extreme.\n- Versus Arrigo Sacchi: Guardiola has been described through an ‘offensive Sacchi’ lens — collective movement, compactness and pressing, but with possession as the central organising principle."
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "**Sources:**"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "- [https://en.wikipedia.org/wiki/Pep_Guardiola](https://en.wikipedia.org/wiki/Pep_Guardiola)\n- [https://www.bbc.co.uk/sport/football/articles/cn8p34e12nno](https://www.bbc.co.uk/sport/football/articles/cn8p34e12nno)\n- [https://www.bbc.com/sport/football/articles/cn8p34e12nno](https://www.bbc.com/sport/football/articles/cn8p34e12nno)\n- [https://www.thehindu.com/sport/football/pep-guardiola-the-manager-who-stood-tall/article71042521.ece](https://www.thehindu.com/sport/football/pep-guardiola-the-manager-who-stood-tall/article71042521.ece)\n- [https://www.straitstimes.com/sport/football/pep-guardiola-catalan-genius-who-changed-football](https://www.straitstimes.com/sport/football/pep-guardiola-catalan-genius-who-changed-football)\n- [https://sports.yahoo.com/articles/architect-redefined-football-why-guardiola-055756222.html](https://sports.yahoo.com/articles/architect-redefined-football-why-guardiola-055756222.html)\n- [https://www.espn.com/soccer/story/_/id/48845495/pep-guardiola-manager-season-ranking-barcelona-manchester-city-bayern-munich](https://www.espn.com/soccer/story/_/id/48845495/pep-guardiola-manager-season-ranking-barcelona-manchester-city-bayern-munich)\n- [https://www.aa.com.tr/en/sports/profile-pep-guardiola-exits-after-conquering-football-and-speaking-beyond-it/3947537](https://www.aa.com.tr/en/sports/profile-pep-guardiola-exits-after-conquering-football-and-speaking-beyond-it/3947537)"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "---"
+          },
+          "metadata": {}
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add a new Jupyter notebook demonstrating the Exa Agent API for conducting tactical and career research on football managers. The notebook uses the Exa search agent to gather comprehensive information on managers and structure it into detailed reports.

## Key Changes
- **New notebook**: `EXA_Agent_Extended_Football_Managers.ipynb` - A complete example workflow showing:
  - Installation of the `exa_py` library
  - Configuration of manager inputs and research query parameters
  - Agent API initialization with Exa credentials
  - Asynchronous agent run creation with structured output schema
  - Polling for completion and result retrieval
  - Markdown rendering of multi-field research reports

- **Research capability**: Demonstrates agent-driven research covering:
  - Tactical philosophy and preferred formations
  - Career history and trophy achievements
  - Key strengths and weaknesses
  - Peer comparisons and rivalries
  - Source URL attribution

- **Output schema**: Defines a structured JSON schema for agent responses with required fields for manager name, overview, tactical systems, career history, strengths, weaknesses, peer comparisons, and source URLs

## Implementation Details
- Uses the `agent-2026-05-07` beta API for agent runs
- Implements polling pattern with `poll_until_finished()` to wait for async completion
- Includes example data for José Mourinho and Pep Guardiola
- Renders results using IPython Markdown display for readable formatting
- Demonstrates proper error handling and output validation

https://claude.ai/code/session_01RyNCxv3js1tWEW13r2hju3